### PR TITLE
Updated Boost version pinning

### DIFF
--- a/.ci_support/linux_64_python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 assimp:
 - '5.2'
 boost_cpp:
-- 1.74.0
+- 1.65
 c_compiler:
 - gcc
 c_compiler_version:
@@ -26,7 +26,8 @@ numpy:
 - '1.19'
 pin_run_as_build:
   boost-cpp:
-    max_pin: x.x.x
+    min_pin: x.x
+    max_pin: x
   flann:
     max_pin: x.x.x
   jsoncpp:

--- a/.ci_support/linux_64_python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 assimp:
 - '5.2'
 boost_cpp:
-- 1.74.0
+- 1.65
 c_compiler:
 - gcc
 c_compiler_version:
@@ -26,7 +26,8 @@ numpy:
 - '1.19'
 pin_run_as_build:
   boost-cpp:
-    max_pin: x.x.x
+    min_pin: x.x
+    max_pin: x
   flann:
     max_pin: x.x.x
   jsoncpp:

--- a/.ci_support/win_64_python3.8.____cpython.yaml
+++ b/.ci_support/win_64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 assimp:
 - '5.2'
 boost_cpp:
-- 1.74.0
+- 1.65
 c_compiler:
 - vs2019
 channel_sources:
@@ -18,7 +18,8 @@ numpy:
 - '1.19'
 pin_run_as_build:
   boost-cpp:
-    max_pin: x.x.x
+    min_pin: x.x
+    max_pin: x
   flann:
     max_pin: x.x.x
   jsoncpp:

--- a/.ci_support/win_64_python3.9.____cpython.yaml
+++ b/.ci_support/win_64_python3.9.____cpython.yaml
@@ -1,7 +1,7 @@
 assimp:
 - '5.2'
 boost_cpp:
-- 1.74.0
+- 1.65
 c_compiler:
 - vs2019
 channel_sources:
@@ -18,7 +18,8 @@ numpy:
 - '1.19'
 pin_run_as_build:
   boost-cpp:
-    max_pin: x.x.x
+    min_pin: x.x
+    max_pin: x
   flann:
     max_pin: x.x.x
   jsoncpp:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -127,7 +127,7 @@ test:
 
 build:
   skip: true # [py<38]
-  number: 1
+  number: 2
 
 about:
   home: https://github.com/ros-industrial-consortium/tesseract


### PR DESCRIPTION
Updates the version pinning of boost to require versions between 1.65.x <= boost < 2.x.x. Version 1.65 is the version distributed on Ubuntu Bionic, which is the earliest distribution for which we have a CI build on the `tesseract` repos